### PR TITLE
Modified the return values and modified parsed Config struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /env
 *.env
+ref.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+current_dir = $(shell pwd)
+run:
+	go run .
+
+test:
+	go test -v -cover -short ./...
+
+.PHONY: run test

--- a/environ.go
+++ b/environ.go
@@ -1,32 +1,27 @@
 package environ
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 )
 
-type config struct {
-	env map[string]any
-}
-
-//Init initializes the environment configurations and returns a map of key value
-func Init(path string) (map[string]any, error) {
-	config, err := loadConfig(path)
-	if err != nil || config == nil {
-		return nil, err
+//Init initializes the environment configurations and returns an error if it occurs.
+func Init(path string, conc any) (error) {
+	err := loadConfig(path, &conc)
+	if err != nil {
+		return err
 	}
 
-	fmt.Println(config.env)
-
-	return config.env, nil
+	return nil
 }
 
-// loadConfig takes the file path of the .env file and generates a
-func loadConfig(filepath string) (*config, error) {
+// loadConfig takes the file path of the .env file and parses the values to the config struct 
+func loadConfig(filepath string, conc *any) (error) {
 	data, err := os.ReadFile(filepath)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("error encoutered reading env file, %v", err)
 	}
 
 	dataString := string(data)
@@ -40,14 +35,19 @@ func loadConfig(filepath string) (*config, error) {
 	configMap := make(map[string]any)
 	for i := 0; i < len(keyVal); i++ {
 		if len(keyVal[i]) != 2 {
-			return nil, err
+			return fmt.Errorf("error related to env variable, make sure it is properly set, %v", err)
 		}
 		configMap[keyVal[i][0]] = keyVal[i][1]
 	}
 
-	config := &config{
-		env: configMap,
+	keystring, err := json.Marshal(configMap)
+	if err != nil {
+		return fmt.Errorf("error encoutered trying to marshal configMap, %v", err)
+	}
+	err = json.Unmarshal(keystring, &conc)
+	if err != nil {
+		return fmt.Errorf("error encoutered trying to unmarshall config struct, %v", err)
 	}
 
-	return config, nil
+	return nil
 }

--- a/environ_test.go
+++ b/environ_test.go
@@ -2,14 +2,23 @@ package environ_test
 
 import (
 	"testing"
+
 	environ "github.com/gentcod/environ"
 	"github.com/stretchr/testify/require"
 )
 
+
+type Config struct {
+	Port string `mapstructure:"PORT"`
+	Url string `mapstructure:"URL"`
+	Key string `mapstructure:"KEY"`
+}
+
 func TestEnviron(t *testing.T) {
 	filepath := "./env/test.env"
-	env, err := environ.Init(filepath)
+	var conc Config
+	err := environ.Init(filepath, &conc)
 
-	require.NotEmpty(t, env)
+	require.NotEmpty(t, conc)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
- The return value was modified to be only an error, if it occurs
- Instead of returning a map containing the environment variables, the memory address of the struct for the config is parsed, this way the fields are updated.

Instead of accessing the values in the form:  `config["Port"]`, it is now accessed in the from: `config.Port`